### PR TITLE
fix: kubectl (and other process that daemonizes) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "pmrs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmrs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/process.rs
+++ b/src/process.rs
@@ -21,11 +21,18 @@ pub enum ProcessStatus {
 }
 
 pub fn start_process(command_string: &String) -> Result<u32> {
+    // Wrap the command to run it in the background and then wait
+    // In the Unix world, many processes will "daemonize" themselves.
+    // This means they fork off a child process and then the parent process exits.
+    // This has the effect of disconnecting the process from the terminal that started it, making it a "background" process or "daemon".
+    // One way to handle this would be to wrap your command in a shell script that blocks until the child process exits.
+    let wrapped_command_string = format!("trap 'kill $!' SIGTERM; {} & wait $!", command_string);
+
     // Execute
     let mut command = Command::new("sh");
     let cp = command
         .arg("-c")
-        .arg(command_string.clone())
+        .arg(wrapped_command_string)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .stdin(Stdio::null())


### PR DESCRIPTION
Kubectl support 

Able to start and stop kubectl port-forward processes with pmrs. 